### PR TITLE
ARXIVNG-457 new test cases and generalization of classic_workflow test

### DIFF
--- a/Dockerfile-metadata
+++ b/Dockerfile-metadata
@@ -1,6 +1,6 @@
 # arxiv/submission-api
 
-FROM arxiv/base
+FROM arxiv/base:0.6.1
 
 WORKDIR /opt/arxiv
 

--- a/authorization/Dockerfile
+++ b/authorization/Dockerfile
@@ -2,7 +2,7 @@
 #
 # This is a simple mockup for an eventual authorization service.
 
-FROM arxiv/base
+FROM arxiv/base:0.6.1
 
 WORKDIR /opt/arxiv
 

--- a/core/events/tests/test_classic_integration.py
+++ b/core/events/tests/test_classic_integration.py
@@ -1,3 +1,12 @@
+"""
+Provides test cases for the new events model's ability to replicate the classic
+model. The function `TestClassicUIWorkflow.test_classic_workflow()` provides
+keyword arguments to pass different types of data through the workflow.
+
+TODO: Presently, `test_classic_workflow` expects `core.domain` objects. That
+should change to instantiate each object at runtime for database imports.
+"""
+
 from unittest import TestCase, mock
 from contextlib import contextmanager
 from flask import Flask
@@ -35,6 +44,8 @@ class TestClassicUIWorkflow(TestCase):
 
     def test_classic_workflow(self, submitter=None, metadata=None, authors=None):
         """Submitter proceeds through workflow in a linear fashion."""
+
+        # Instantiate objects that have not yet been instantiated or use defaults.
         if submitter is None:
             submitter = self.submitter
 
@@ -48,7 +59,8 @@ class TestClassicUIWorkflow(TestCase):
                 ('journal_ref', 'Foo Rev 1, 2 (1903)')
             ]
 
-
+        
+        # TODO: Process data in dictionary form to events.Author objects.
         if authors is None:
             authors = [events.Author(order=0,
                                      forename='Bob',

--- a/core/events/tests/test_classic_integration.py
+++ b/core/events/tests/test_classic_integration.py
@@ -324,3 +324,140 @@ class TestClassicUIWorkflow(TestCase):
 
             self.assertEqual(len(stack), 8,
                              "Eight commands have been executed in total.")
+
+    def test_texism_titles(self):
+        """Submitter proceeds through workflow in a linear fashion."""
+        with in_memory_db() as session:
+            # Submitter clicks on 'Start new submission' in the user dashboard.
+            submission, stack = events.save(
+                events.CreateSubmission(creator=self.submitter)
+            )
+            self.assertIsNotNone(submission.submission_id,
+                                 "A submission ID is assigned")
+            self.assertEqual(len(stack), 1, "A single command is executed.")
+
+            db_submission = session.query(classic.models.Submission)\
+                .get(submission.submission_id)
+            # submitter info tested in other test
+
+            # TODO: What else to check here?
+
+            # /start: Submitter completes the start submission page.
+            license_uri = 'http://creativecommons.org/publicdomain/zero/1.0/'
+            submission, stack = events.save(
+                events.VerifyContactInformation(creator=self.submitter),
+                events.AssertAuthorship(
+                    creator=self.submitter,
+                    submitter_is_author=True
+                ),
+                events.SelectLicense(
+                    creator=self.submitter,
+                    license_uri=license_uri,
+                    license_name='CC0 1.0'
+                ),
+                events.AcceptPolicy(creator=self.submitter),
+                events.SetPrimaryClassification(
+                    creator=self.submitter,
+                    category='cs.DL'
+                ),
+                submission_id=submission.submission_id
+            )
+            self.assertEqual(len(stack), 6,
+                             "Six commands have been executed in total.")
+
+            db_submission = session.query(classic.models.Submission)\
+                .get(submission.submission_id)
+            self.assertEqual(db_submission.userinfo, 1,
+                             "Contact verification set correctly in database.")
+            self.assertEqual(db_submission.is_author, 1,
+                             "Authorship status set correctly in database.")
+            self.assertEqual(db_submission.license, license_uri,
+                             "License set correctly in database.")
+            self.assertEqual(db_submission.agree_policy, 1,
+                             "Policy acceptance set correctly in database.")
+            self.assertEqual(len(db_submission.categories), 1,
+                             "A single category is associated in the database")
+            self.assertEqual(db_submission.categories[0].is_primary, 1,
+                             "Primary category is set correct in the database")
+            self.assertEqual(db_submission.categories[0].category, 'cs.DL',
+                             "Primary category is set correct in the database")
+
+            # /addfiles: Submitter has uploaded files to the file management
+            # service, and verified that they compile. Now they associate the
+            # content package with the submission.
+            submission, stack = events.save(
+                events.AttachSourceContent(
+                    creator=self.submitter,
+                    location="https://submit.arxiv.org/upload/123",
+                    checksum="a9s9k342900skks03330029k",
+                    format='tex',
+                    mime_type="application/zip",
+                    identifier=123,
+                    size=593992
+                ),
+                submission_id=submission.submission_id
+            )
+
+            self.assertEqual(len(stack), 7,
+                             "Seven commands have been executed in total.")
+            db_submission = session.query(classic.models.Submission)\
+                .get(submission.submission_id)
+            self.assertEqual(db_submission.must_process, 0,
+                             "Processing status is set correctly in database")
+            self.assertEqual(db_submission.source_size, 593992,
+                             "Source package size set correctly in database")
+            self.assertEqual(db_submission.source_format, 'tex',
+                             "Source format set correctly in database")
+
+            # /metadata: Submitter adds metadata to their submission, including
+            # authors. In this package, we model authors in more detail than
+            # in the classic system, but we should preserve the canonical
+            # format in the db for legacy components' sake.
+            metadata = [
+                ('title', 'Revisiting $E = mc^2$'),
+                ('abstract', "$E = mc^2$ is a foundational concept in physics"),
+                ('comments', '5 pages, 2 turtle doves'),
+                ('report_num', 'asdf1234'),
+                ('doi', '10.01234/56789'),
+                ('journal_ref', 'Foo Rev 1, 2 (1903)')
+            ]
+            submission, stack = events.save(
+                events.UpdateMetadata(
+                    creator=self.submitter,
+                    metadata=metadata
+                ),
+                events.UpdateAuthors(
+                    creator=self.submitter,
+                    authors=[events.Author(
+                        order=0,
+                        forename='Bob',
+                        surname='Paulson',
+                        email='Robert.Paulson@nowhere.edu',
+                        affiliation='Fight Club'
+                    )]
+                ),
+                submission_id=submission.submission_id
+            )
+            db_submission = session.query(classic.models.Submission)\
+                .get(submission.submission_id)
+            self.assertEqual(db_submission.title, dict(metadata)['title'],
+                             "Title updated as expected in database")
+            self.assertEqual(db_submission.abstract,
+                             dict(metadata)['abstract'],
+                             "Abstract updated as expected in database")
+            self.assertEqual(db_submission.comments,
+                             dict(metadata)['comments'],
+                             "Comments updated as expected in database")
+            self.assertEqual(db_submission.report_num,
+                             dict(metadata)['report_num'],
+                             "Report number updated as expected in database")
+            self.assertEqual(db_submission.doi, dict(metadata)['doi'],
+                             "DOI updated as expected in database")
+            self.assertEqual(db_submission.journal_ref,
+                             dict(metadata)['journal_ref'],
+                             "Journal ref updated as expected in database")
+            self.assertEqual(db_submission.authors, "Bob Paulson (Fight Club)",
+                             "Authors updated in canonical format in database")
+
+            self.assertEqual(len(stack), 9,
+                             "Nine commands have been executed in total.")


### PR DESCRIPTION
- New test cases for unicode and texisms
- Refactoring of the `test_classic_workflow` case to accomidate future tests of imported arxiv-classic data.
- Pinning `arxiv-base` image to 0.6.1. This was a necessity because the `latest` tag wasn't updated with the newest releases.