### PR TITLE
ARXIVNG-684 Support for optional display name for each author

### DIFF
--- a/core/events/domain/submission.py
+++ b/core/events/domain/submission.py
@@ -37,18 +37,26 @@ class License:
 class Author:
     """Represents an author of a submission."""
 
-    order: int
+    order: int = field(default=0)
     forename: str = field(default_factory=str)
     surname: str = field(default_factory=str)
     initials: str = field(default_factory=str)
     affiliation: str = field(default_factory=str)
     email: str = field(default_factory=str)
-    identifier: Optional[str] = None
+    identifier: Optional[str] = field(default=None)
+    display: Optional[str] = field(default=None)
+    """
+    Submitter may include a preferred display name for each author.
+
+    If not provided, will be automatically generated from the other fields.
+    """
 
     def __post_init__(self) -> None:
         """Auto-generate an identifier, if not provided."""
         if not self.identifier:
             self.identifier = self._generate_identifier()
+        if not self.display:
+            self.display = self.canonical
 
     def _generate_identifier(self):
         h = hashlib.new('sha1')
@@ -104,8 +112,8 @@ class SubmissionMetadata:
 
     @property
     def authors_canonical(self):
-        """Canonical representation of submission authors."""
-        return ", ".join([au.canonical for au in self.authors])
+        """Canonical representation of authors, using display names."""
+        return ", ".join([au.display for au in self.authors])
 
     def to_dict(self) -> dict:
         """Generate dict representation of :class:`.SubmissionMetadata`."""

--- a/metadata/examples/complete_submission.json
+++ b/metadata/examples/complete_submission.json
@@ -34,12 +34,14 @@
         "initials": "G. G.",
         "surname": "Byron",
         "email": "lord.byron@Μεσολόγγι.gr",
-        "identifier": "https://orcid.org/0000-0001-2345-6789"
+        "identifier": "https://orcid.org/0000-0001-2345-6789",
+        "display": "Lord G. G. Byron"
       },
       {
         "forename": "Tom",
         "surname": "Bombadil",
-        "email": "tom@oldforest.co.uk"
+        "email": "tom@oldforest.co.uk",
+        "display": "T. Bombadil, esq."
       }
     ]
   }

--- a/metadata/examples/complete_submission.json
+++ b/metadata/examples/complete_submission.json
@@ -42,6 +42,11 @@
         "surname": "Bombadil",
         "email": "tom@oldforest.co.uk",
         "display": "T. Bombadil, esq."
+      },
+      {
+        "forename": "Frank",
+        "surname": "Landau",
+        "email": "f@landau.gov"
       }
     ]
   }

--- a/metadata/schema/resources/metadata.json
+++ b/metadata/schema/resources/metadata.json
@@ -55,6 +55,10 @@
             "description": "Author authority record URI. This may be an arXiv authority URI or an ORCID identifier.",
             "type": "string",
             "format": "uri"
+          },
+          "display": {
+            "description": "The preferred display representation of the author's name and affiliation.",
+            "type": "string"
           }
         }
       }

--- a/metadata/tests/test_examples.py
+++ b/metadata/tests/test_examples.py
@@ -74,6 +74,19 @@ class TestSubmit(TestCase):
         except jsonschema.ValidationError as e:
             self.fail("Return content should match submission schema")
 
+        # Verify that author metadata was preserved.
+        rq_authors = data['metadata']['authors']
+        re_authors = response_data['metadata']['authors']
+        for rq_author, re_author in zip(rq_authors, re_authors):
+            self.assertEqual(rq_author['forename'], re_author['forename'])
+            self.assertEqual(rq_author['surname'], re_author['surname'])
+            self.assertEqual(rq_author['email'], re_author['email'])
+            if 'display' in rq_author:
+                self.assertEqual(rq_author['display'], re_author['display'])
+            else:
+                self.assertGreater(len(re_author['display']), 0,
+                                   "Should be set automatically")
+
     def test_alter_submission_before_finalization(self):
         """Client submits a partial record, and then updates it."""
         example = os.path.join(BASEPATH, 'examples/complete_submission.json')


### PR DESCRIPTION
- Used by SubmissionMetdata.authors_canonical to generate the author string
- If not provided, automatically generated from the provided fields