### PR TITLE
ARXIVNG-904 RemoveSubmission event "deletes" a submission

### DIFF
--- a/core/arxiv/submission/domain/submission.py
+++ b/core/arxiv/submission/domain/submission.py
@@ -170,8 +170,8 @@ class Submission:
 
     @property
     def published(self) -> bool:
-        """The submission has been announced."""
-        return self.status == self.PUBLISHED
+        """The submission has been (or is about to be) announced."""
+        return self.status in [self.PUBLISHED, self.SCHEDULED]
 
     @property
     def finalized(self) -> bool:
@@ -180,7 +180,7 @@ class Submission:
 
     @property
     def deleted(self) -> bool:
-        """Submission is deleted (removed)."""
+        """Submission is removed."""
         return self.status == self.DELETED
 
     def to_dict(self) -> dict:

--- a/core/arxiv/submission/domain/submission.py
+++ b/core/arxiv/submission/domain/submission.py
@@ -178,6 +178,11 @@ class Submission:
         """Submitter has indicated submission is ready for publication."""
         return self.status not in [self.WORKING, self.DELETED]
 
+    @property
+    def deleted(self) -> bool:
+        """Submission is deleted (removed)."""
+        return self.status == self.DELETED
+
     def to_dict(self) -> dict:
         """Generate a dict representation of this :class:`.Submission`."""
         data = asdict(self)

--- a/core/arxiv/submission/domain/submission.py
+++ b/core/arxiv/submission/domain/submission.py
@@ -151,13 +151,7 @@ class Submission:
     client: Optional[Agent] = field(default=None)
     submission_id: Optional[int] = field(default=None)
     metadata: SubmissionMetadata = field(default_factory=SubmissionMetadata)
-    active: bool = field(default=True)
-    """Actively moving through the submission workflow."""
 
-    finalized: bool = field(default=False)
-    """Submitter has indicated submission is ready for publication."""
-
-    published: bool = field(default=False)
     secondary_classification: List[Classification] = \
         field(default_factory=list)
     submitter_contact_verified: bool = field(default=False)
@@ -168,6 +162,21 @@ class Submission:
     status: str = field(default=WORKING)
     arxiv_id: Optional[str] = field(default=None)
     """The published arXiv paper ID."""
+
+    @property
+    def active(self) -> bool:
+        """Actively moving through the submission workflow."""
+        return self.status not in [self.DELETED, self.PUBLISHED]
+
+    @property
+    def published(self) -> bool:
+        """The submission has been announced."""
+        return self.status == self.PUBLISHED
+
+    @property
+    def finalized(self) -> bool:
+        """Submitter has indicated submission is ready for publication."""
+        return self.status not in [self.WORKING, self.DELETED]
 
     def to_dict(self) -> dict:
         """Generate a dict representation of this :class:`.Submission`."""

--- a/core/arxiv/submission/services/classic/models.py
+++ b/core/arxiv/submission/services/classic/models.py
@@ -205,9 +205,9 @@ class Submission(Base):    # type: ignore
         """
         # Status changes.
         submission.status = self._get_status()
-        submission.active = (submission.status not in
-                             [submission.DELETED, submission.PUBLISHED])
-        submission.published = (submission.status == submission.PUBLISHED)
+        # submission.active = (submission.status not in
+        #                      [submission.DELETED, submission.PUBLISHED])
+        # submission.published = (submission.status == submission.PUBLISHED)
         submission.arxiv_id = self._get_arxiv_id()
 
         # Possible reclassification.

--- a/core/arxiv/submission/services/classic/models.py
+++ b/core/arxiv/submission/services/classic/models.py
@@ -320,6 +320,9 @@ class Submission(Base):    # type: ignore
                 and self.status in [Submission.NOT_SUBMITTED, None]:
             self.status = Submission.SUBMITTED
             self.submit_time = submission.updated
+        # Delete.
+        elif submission.deleted:
+            self.status = Submission.DELETED_USER
         # Unsubmit.
         elif self.status is None or self.status <= Submission.ON_HOLD:
             if not submission.finalized:

--- a/core/arxiv/submission/tests/test_classic_integration.py
+++ b/core/arxiv/submission/tests/test_classic_integration.py
@@ -534,7 +534,7 @@ class TestPublicationIntegration(TestCase):
                              "Submission should have error status.")
 
     def test_deleted(self):
-        """The submission was deleted."""
+        """The submission was deleted by the classic system."""
         with self.app.app_context():
             session = classic.current_session()
 
@@ -550,3 +550,17 @@ class TestPublicationIntegration(TestCase):
                 submission, _ = load(self.submission.submission_id)
                 self.assertEqual(submission.status, submission.DELETED,
                                  "Submission should have deleted status.")
+
+    def test_deleted_in_ng(self):
+        """The submission was deleted in this package."""
+        with self.app.app_context():
+            session = classic.current_session()
+            self.submission, _ = save(
+                RemoveSubmission(creator=self.submitter),
+                submission_id=self.submission.submission_id
+            )
+
+            db_submission = session.query(classic.models.Submission)\
+                .get(self.submission.submission_id)
+            self.assertEqual(db_submission.status,
+                             classic.models.Submission.DELETED_USER)


### PR DESCRIPTION
We already had a ``RemoveSubmission`` command, but it didn't do much. This change makes sure that the submission is marked as deleted by user in the database when the ``RemoveSubmission`` command is used. The command will only be valid for submissions that are not already removed, and that are not scheduled/published.

I also consolidated some redundant stuff on the ``Submission`` domain class: we were using both the ``status`` field as well as boolean fields (``active``, ``published``, etc) that conveyed redundant information. It's kind of nice to have the latter as predicates, so I went ahead and changed them to read-only properties so that we can continue to use them but don't end up in weird states accidentally.